### PR TITLE
#160505877 Add related articles under an article being read

### DIFF
--- a/src/components/relatedArticles/relatedArticles.js
+++ b/src/components/relatedArticles/relatedArticles.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import Wrapper from '../../hoc/Wrapper/Wrapper';
+import classes from '../../CSS/index.css';
+
+const RelatedArticles = () => {
+  const articleDiv = ['col-12 col-md-6 col-lg-4', classes.articleDiv].join(' ');
+  const articleImg = ['img1', classes.articleImg].join(' ');
+  return (
+    <Wrapper>
+      <h4>RELATED ARTICLES</h4>
+      <div className="row ">
+        <div className={articleDiv}>
+          <img
+            src="https://images.unsplash.com/photo-1530989109-7aa8e4318cc7?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=267781c6915b71ff63a82317507b0000&auto=format&fit=crop&w=1350&q=80"
+            alt=""
+            className={articleImg}
+          />
+          <h5>Classic cars still rule...</h5>
+          <p className={classes.titleParagraph}>
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
+            has been the industry&apos;s standard dummy text ever since the 1500s, when an unknown
+            printer took a galley of type and scrambled it to make a type specimen book.
+          </p>
+          <p className={classes.authorTag}>Author: Riz Ahmed Jan 1st, 2018</p>
+        </div>
+        <div className={articleDiv}>
+          <img
+            src="https://images.unsplash.com/photo-1453491945771-a1e904948959?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=6293f851bba5d5016c47c9695b3adc52&auto=format&fit=crop&w=1350&q=80"
+            alt=""
+            className={articleImg}
+          />
+          <h5>Why you should own a Tesla</h5>
+          <p className={classes.titleParagraph}>
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
+            has been the industry&apos;s standard dummy text ever since the 1500s, when an unknown
+            printer took a galley of type and scrambled it to make a type specimen book.
+          </p>
+          <p className={classes.authorTag}>Author: Seki Rahu April 20th, 2018</p>
+        </div>
+        <div className={articleDiv}>
+          <img
+            src="https://images.unsplash.com/photo-1525577288853-c6f0a020a162?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=a76ff2c0280c0fcd31b5120ce3f11131&auto=format&fit=crop&w=1350&q=80"
+            alt=""
+            className={articleImg}
+          />
+          <h5>Where the rich vacation</h5>
+          <p className={classes.titleParagraph}>
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
+            has been the industry&apos;s standard dummy text ever since the 1500s, when an unknown
+            printer took a galley of type and scrambled it to make a type specimen book.
+          </p>
+          <p className={classes.authorTag}>Author: Tar Ancalime Aug 18th, 2018</p>
+        </div>
+      </div>
+      <hr style={{ width: '100%' }} />
+    </Wrapper>
+  );
+};
+
+export default RelatedArticles;

--- a/src/containers/Articles/Article.js
+++ b/src/containers/Articles/Article.js
@@ -7,7 +7,7 @@ import classes from '../../CSS/Article.css';
 import Wrapper from '../../hoc/Wrapper/Wrapper';
 import CreateComment from '../Comments/CreateComment';
 import ArticleLoader from '../Loaders/ArticleLoader';
-import Recent from '../../components/Recent/Recent';
+import RelatedArticles from '../../components/relatedArticles/relatedArticles';
 
 
 export class Article extends Component {
@@ -129,7 +129,7 @@ export class Article extends Component {
                       </div>
                       <StarRatingComponent name="rate1" starCount={5} onStarClick={this.onStarClick} renderStarIcon={() => <span><i className="fa fa-star-o" /></span>} />
                     </div>
-                    <Recent />
+                    <RelatedArticles />
                     <CreateComment slug={match.params.slug} />
                   </div>
                 )

--- a/src/tests/components/RelatedArticles.test.js
+++ b/src/tests/components/RelatedArticles.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import RelatedArticles from '../../components/relatedArticles/relatedArticles';
+
+describe('<RelatedArticles />', () => {
+  it('should render three images', () => {
+    const wrapper = shallow(<RelatedArticles />);
+    expect(wrapper.find('img')).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
- Adds dummy related articles to an article that is being read.

### How should this be manually tested?
- click on an article and scroll down to view related articles

### Any background context you want to provide?
- On the request of the PO, I added these dummy articles to this page.

### What are the relevant pivotal tracker stories?
- [#160505877](https://www.pivotaltracker.com/story/show/160505877)
<img width="976" alt="screen shot 2018-09-14 at 12 36 17 pm" src="https://user-images.githubusercontent.com/29429135/45542531-da8af380-b81a-11e8-8a37-85872701e22c.png">
