### PR TITLE
#159951824 Show message when there are no comments

### DIFF
--- a/src/containers/Comments/CreateComment.js
+++ b/src/containers/Comments/CreateComment.js
@@ -31,8 +31,14 @@ export class CreateComment extends Component {
         },
       )
       .then(response => {
+        let makeClickable = true;
+        if (response.data.results.length === 0 || response.data.next === null) {
+          makeClickable = false;
+        }
         const sorteData = this.sorter(response.data.results);
-        this.setState({ CommentsData: sorteData, next: response.data.next });
+        this.setState({
+          CommentsData: sorteData, next: response.data.next, makeClickable,
+        });
       });
   }
 
@@ -99,7 +105,7 @@ export class CreateComment extends Component {
 
   render() {
     const {
-      CommentsData, body, LoadingComments, LoadingMessage, errorMsg,
+      CommentsData, body, LoadingComments, LoadingMessage, errorMsg, makeClickable,
     } = this.state;
     return (
       <div className={classes.detailBox}>
@@ -135,7 +141,7 @@ export class CreateComment extends Component {
                     <h6 className={classes.loading}>{LoadingMessage}</h6>
                   )
                   : (
-                    <NavLink id="nav" className={classes.loadMore} onClick={this.Pagination} to="#"><h6>Click to view more comments</h6></NavLink>
+                    <NavLink id="nav" className={classes.loadMore} onClick={makeClickable ? this.Pagination : null} to="#"><h6>{makeClickable ? 'Click to view more comments.' : 'Got something in mind? Add a comment.'}</h6></NavLink>
                   )
                 }
               </center>

--- a/src/tests/containers/Comments.test.js
+++ b/src/tests/containers/Comments.test.js
@@ -12,10 +12,15 @@ it('<CommentBody />', () => {
 
 describe('tests for comments', () => {
   let wrapper;
-  const CommentData = [
-    { body: 'body', created_at: '12/11/10', author: { userename: 'myUser', image: 'url.com' } },
-    { body: 'body', created_at: '12/11/10', author: { userename: 'myUser', image: 'url.com' } },
-  ];
+  const CommentData = {
+    data: {
+      next: 'someUrl.com',
+      results: [
+        { body: 'body', created_at: '12/11/10', author: { userename: 'myUser', image: 'url.com' } },
+        { body: 'body', created_at: '12/11/10', author: { userename: 'myUser', image: 'url.com' } },
+      ],
+    },
+  };
   const createSpy = (toSpy) => jest.spyOn(wrapper.instance(), toSpy);
 
   beforeEach(() => {
@@ -63,9 +68,10 @@ describe('tests for comments', () => {
     expect(eventListener).toHaveBeenCalled();
   });
 
-  it('should call event Pagination function', () => {
+  it('should call Pagination function', () => {
     const eventListener = createSpy('Pagination');
     wrapper.instance().forceUpdate();
+    wrapper.setState({ makeClickable: true });
     wrapper.find('#nav').simulate('click', { preventDefault: () => {} });
     expect(eventListener).toHaveBeenCalled();
   });


### PR DESCRIPTION
### What does this PR do?
- Hides the pagination link when there are no other comments

### How should this be manually tested?
- Create a new article with no comments
- Scroll down to comments

### Any background context you want to provide?
- I used states to change the messages shown

### What are the relevant pivotal tracker stories?
- [#159951824](https://www.pivotaltracker.com/story/show/159951824)

<img width="987" alt="screen shot 2018-09-17 at 12 17 19 pm" src="https://user-images.githubusercontent.com/29429135/45614909-b118d480-ba73-11e8-88c7-576f70b3481b.png">
