### PR TITLE
#159951833 Add article reading time to an article

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-social-login-buttons": "^2.1.2",
     "react-star-rating-component": "^1.4.1",
     "react-test-renderer": "^16.4.2",
+    "reading-time": "^1.1.3",
     "redux": "^4.0.0",
     "redux-mock-store": "^1.5.3",
     "redux-thunk": "^2.3.0",

--- a/src/CSS/Article.css
+++ b/src/CSS/Article.css
@@ -77,3 +77,7 @@ label{
 .articlesList li {
     list-style: none;
 }
+
+.lowercase {
+  text-transform: lowercase !important;
+}

--- a/src/containers/Articles/ArticleDetail/ArticleDetail.js
+++ b/src/containers/Articles/ArticleDetail/ArticleDetail.js
@@ -4,6 +4,7 @@ import { NavLink } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import provideScrollPosition from 'react-provide-scroll-position';
 import StarRatingComponent from 'react-star-rating-component';
+import readingTime from 'reading-time';
 import classes from '../../../CSS/Article.css';
 import Wrapper from '../../../hoc/Wrapper/Wrapper';
 
@@ -74,6 +75,15 @@ export class ArticleDetail extends Component {
     }));
   }
 
+  readTime = () => {
+    const { articleData } = this.state;
+    let timeMin = Math.floor(readingTime(`${articleData.body}`).minutes);
+    if (timeMin <= 1) {
+      timeMin = 1;
+    }
+    return timeMin;
+  };
+
   render() {
     const {
       showLoader,
@@ -140,9 +150,13 @@ export class ArticleDetail extends Component {
                       }`}
                     >
                       {articleData.author.username}
-                      &nbsp;|&nbsp;
+                      &nbsp; | &nbsp;
                       {new Date(articleData.created_at).toLocaleDateString('en-BR', options)}
-                      &nbsp;|&nbsp; 2 Min read
+                      &nbsp; | &nbsp;
+                      <span className={`${classes.spanDesAuthor} ${classes.lowercase}`}>
+                        {this.readTime()}
+                      &nbsp; min read
+                      </span>
                     </span>
                     <br />
                     <img

--- a/src/tests/containers/ArticleDetail.test.js
+++ b/src/tests/containers/ArticleDetail.test.js
@@ -115,6 +115,25 @@ describe('displaying article by slug ', () => {
     expect(result).toBeInstanceOf(Promise);
   });
 
+  it('return one minute for any short article', async () => {
+    const props = {
+      match: {
+        params: {
+          slug: 'slug',
+        },
+      },
+    };
+
+    const wrapper = mount(<ArticleDetail {...props} />);
+    moxios.stubRequest('https://authors-haven-tabs.herokuapp.com/api/articles/search?slug=me-and-william', {
+      status: 200,
+      response: data,
+    });
+
+    const timeTaken = await wrapper.instance().readTime();
+    expect(timeTaken).toBe(1);
+  });
+
   it('render comments', () => {
     const wrapper = shallow(<CreateComment />);
     expect(wrapper).toHaveLength(1);


### PR DESCRIPTION
### What does this PR do?
- Allows readers to know how long it takes to read an article

### How should this be manually tested?
- An estimated average reading time has been added to the articles

### Any background context you want to provide?
- I have added a default one minute for short articles.

### What are the relevant pivotal tracker stories?
- [#159951833](https://www.pivotaltracker.com/story/show/159951833)

### Test coverage screenshot
<img width="924" alt="screen shot 2018-09-18 at 13 04 45" src="https://user-images.githubusercontent.com/21138053/45680401-8302c580-bb43-11e8-8e4a-e3f316c9e54d.png">
