### PR TITLE
#159951832 add search functionality on articles and display in masonry grid

### DIFF
--- a/src/CSS/SearchGrid.css
+++ b/src/CSS/SearchGrid.css
@@ -1,10 +1,5 @@
 .container {
-    display: inline-grid;
-    grid-template-columns: auto auto auto;
-    grid-gap: 8px;
-    margin: auto;
-  }
-  .searchGridIndicator {
-    text-align: center;
-  }
-  
+  column-count: 3;
+  column-gap: 1em;
+  height: auto;
+}

--- a/src/CSS/SearchGridItem.css
+++ b/src/CSS/SearchGridItem.css
@@ -1,39 +1,15 @@
-.imageContainer {
-  width: 398px;
-  height: 250px;
-  overflow: hidden;
+.itemComponent {
+  text-align: center;
+  display: inline-block;
 }
-.listImage {
+.itemHeader {
+  text-align: center;
+}
+.itemDescription {
+  text-align: center;
+}
+.itemAuthor {
   width: 100%;
-  height: auto;
-}
-.listTitle {
-  width: 350px;
-  font-family: Arial;
-  margin-left: 25px;
-  margin-bottom: 4px;
-}
-.listDescription {
-  width: 350px;
-  font-family: Arial;
-  margin-left: 25px;
-  margin-bottom: 6px;
-  font-size: 16px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: pre-wrap;
-}
-
-.listDivs {
-  margin-right: 8px;
-  float: left;
-}
-.listOuterContainer {
-  width: 400px;
-  height: 450px;
-  border: 1px solid black;
-  margin-top: 25px;
-}
-.listSpans {
-  margin-left: 25px;
+  text-align: center;
+  color: rgb(95, 95, 95);
 }

--- a/src/components/Search/SearchGridItem.js
+++ b/src/components/Search/SearchGridItem.js
@@ -13,19 +13,18 @@ export class SearchGridItem extends Component {
       image = 'http://res.cloudinary.com/ronzalo777/image/upload/v1537184865/pov5uovdstk7ovjouxhk.png';
     }
     return (
-      <div className={classes.listOuterContainer}>
-        <div className={classes.imageContainer}>
+      <div className={classes.itemComponent}>
+        <div>
           <img
-            className={classes.listImage}
             src={image}
             alt=""
           />
         </div>
         <NavLink to={`/articles/${slug}`}>
-          <h3 className={classes.listTitle}>{title}</h3>
+          <h3 className={classes.itemHeader}>{title}</h3>
         </NavLink>
-        <p className={classes.listDescription}>{description}</p>
-        <span className={classes.listSpans}>{author}</span>
+        <p className={classes.itemDescription}>{description}</p>
+        <p className={classes.itemAuthor}>{author}</p>
       </div>
     );
   }

--- a/src/containers/Header/Header.js
+++ b/src/containers/Header/Header.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import {
   NavLink,
@@ -49,7 +50,8 @@ export class Header extends Component {
     if (context === '' || value === '') {
       window.alert('Please provide all search parameters');
     } else {
-      window.location.assign(`/search/${context}/${value}`);
+      const { history: { push } } = this.props;
+      push(`/search/${context}/${value}`);
     }
   };
 
@@ -253,4 +255,4 @@ const mapDispatchToProps = dispatch => {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(Header);
+)(withRouter(Header));

--- a/src/tests/containers/Header.test.js
+++ b/src/tests/containers/Header.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
 import { BrowserRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
 import { Header } from '../../containers/Header/Header';
 
 describe('<Header />', () => {
@@ -59,8 +61,8 @@ describe('<Header />', () => {
     });
   });
 
-  describe('onSearch', () => {
-    it.skip('mocks search funtionality', () => {
+  describe('setContext', () => {
+    it('changes selected context', () => {
       const props = {
         authStatus: true,
         ProfileDropdownState: true,
@@ -69,16 +71,32 @@ describe('<Header />', () => {
         clickSignup: () => {},
       };
 
-      const parentWrapper = mount(
-        <BrowserRouter>
-          <Header {...props} />
-        </BrowserRouter>,
-      );
-      const wrapper = parentWrapper.find(Header);
-      const spy = jest.spyOn(wrapper.instance(), 'handleSearch');
+      const wrapper = shallow(<Header {...props} />);
+      const spy = jest.spyOn(wrapper.instance(), 'setContext');
       wrapper.instance().forceUpdate();
 
-      wrapper.find('#searchBtn').simulate('click', { preventDefault: () => {} });
+      const newChange = wrapper.find('select[name="contextSelector"]');
+      newChange.simulate('change', { target: { value: 'Author', name: 'contextSelector' } });
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('setValue', () => {
+    it('changes entered value', () => {
+      const props = {
+        authStatus: true,
+        ProfileDropdownState: true,
+        TOGGLE_PROFILE_ACTION: () => {},
+        clickSignin: () => {},
+        clickSignup: () => {},
+      };
+
+      const wrapper = shallow(<Header {...props} />);
+      const spy = jest.spyOn(wrapper.instance(), 'setValue');
+      wrapper.instance().forceUpdate();
+
+      const newChange = wrapper.find('input[name="searchInput"]');
+      newChange.simulate('change', { target: { value: 'phillip', name: 'searchInput' } });
       expect(spy).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
#### What does this PR do?
displays search results in a masonry grid
#### Description of Task to be completed?
Users would be able to filter articles by author, article title and tag/keywords, this would ensure a user only gets an article that matches ONLY the criteria that match the criteria for the article they want.
#### How should this be manually tested?
- Enter a value in the search input
- Click the search button
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/159951832
#### Screenshots (if appropriate)
<img width="1257" alt="screen shot 2018-09-27 at 14 48 17" src="https://user-images.githubusercontent.com/40794916/46144003-70377180-c264-11e8-88ed-079ececaf644.png">
